### PR TITLE
Updated getAvatarUrl so that it uses the current site url

### DIFF
--- a/discourse2/src/main/java/org/goodev/discourse/utils/Utils.java
+++ b/discourse2/src/main/java/org/goodev/discourse/utils/Utils.java
@@ -287,6 +287,10 @@ public class Utils {
             return GRAVATAR_HTTP_PREFIX + template;
         }
 
+        if(!template.startsWith(App.getSiteUrl())) {
+            template = App.getSiteUrl() + template;
+        }
+
         return template.replace(GRAVATAR_SIZE, size + "");
     }
 


### PR DESCRIPTION
I was glad to see you put the source code for this app on GitHub.  I tracked down the immediate crashing issue to a problem with loading the user avatar images.  

I have resolved this problem by making the getAvatarUrl use the App.getSiteUrl() if it's not already an absolute url.
